### PR TITLE
Feature/basic security 

### DIFF
--- a/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig {
 
     @Bean
     public UserDetailsService userDetailsService(){
-        UserDetails user = User.withUsername("admin").password("{noop}admin").build();
+        UserDetails user = User.withUsername("SDMUnifgOdaback8gs2").password("{noop}SDM7Unifg9DJEwh").build();
         return new InMemoryUserDetailsManager(user);
     }
 

--- a/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -1,0 +1,40 @@
+package com.example.demo.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain (HttpSecurity http) throws Exception {
+        http
+                .formLogin(withDefaults())
+                .httpBasic(withDefaults())
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests((request)-> request
+                        .requestMatchers(HttpMethod.POST,"/api/v1/login").permitAll()
+                        .requestMatchers(HttpMethod.POST,"/api/v1/register").permitAll()
+                        .anyRequest().authenticated());
+        return http.build();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService(){
+        UserDetails user = User.withUsername("admin").password("admin").build();
+        return new InMemoryUserDetailsManager(user);
+    }
+
+}

--- a/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig {
 
     @Bean
     public UserDetailsService userDetailsService(){
-        UserDetails user = User.withUsername("admin").password("admin").build();
+        UserDetails user = User.withUsername("admin").password("{noop}admin").build();
         return new InMemoryUserDetailsManager(user);
     }
 


### PR DESCRIPTION
### Add basic security configuration in the SecurityConfig class.
- Authentication is now required for accessing API endpoints, except:
     - POST /api/v1/login
     - POST /api/v1/register

(“login" can be referred to as "auth" — I just noticed this in <a href="https://github.com/UNIFG-PE/front-oda/blob/feature/login/src/screens/LoginScreen.js">#Front-oda/blob/feature/login/src/screens/LoginScreen.js</a>)
### Introduced a temporary in-memory user for authentication purposes.

🔐 In-memory user credentials:
- Username: SDMUnifgOdaback8gs2
- Password: SDM7Unifg9DJEwh

In task #62, show how to authenticate using Postman

(Closes #62) 

(Edited)
Updated credentials - username and password - used by the in-memory user.